### PR TITLE
Postal Code to String

### DIFF
--- a/lib/sg_delivery_slot_checker/checker.rb
+++ b/lib/sg_delivery_slot_checker/checker.rb
@@ -5,7 +5,7 @@ module SgDeliverySlotChecker
   class Checker
 
     def initialize(postal_code:)
-      @postal_code = postal_code
+      @postal_code = postal_code.to_s
     end
 
     def check_availability


### PR DESCRIPTION
Convert postal code to strings to not fail on postal codes that start with zero. Fixes #5 